### PR TITLE
feat: add documents endpoints to get video urls and invoices urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@apollo/subgraph": "^2.0.5",
-        "@aws-sdk/client-s3": "^3.137.0",
+        "@aws-sdk/client-s3": "^3.525.0",
         "@aws-sdk/s3-request-presigner": "3.67.0",
         "@nestjs/apollo": "^12.0.0",
         "@nestjs/common": "^10.0.0",
@@ -55,7 +55,7 @@
         "typescript": "^5.5.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": "^16 || ^20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -729,410 +729,555 @@
       }
     },
     "node_modules/@aws-crypto/crc32": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
       "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
-    },
-    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/crc32c": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
-      "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
       "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
+        "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha1-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
-      "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-s3": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.496.0.tgz",
-      "integrity": "sha512-Q16iIP8SmM/7uWHbTCRnvXgM+RxgEDHQmkKL1bvdPLhfu4q1+RwWwJ/WS+1amwQtwvWc8Z51W4XEsokJmqOYUA==",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "3.0.0",
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.496.0",
-        "@aws-sdk/core": "3.496.0",
-        "@aws-sdk/credential-provider-node": "3.496.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.496.0",
-        "@aws-sdk/middleware-expect-continue": "3.496.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.496.0",
-        "@aws-sdk/middleware-host-header": "3.496.0",
-        "@aws-sdk/middleware-location-constraint": "3.496.0",
-        "@aws-sdk/middleware-logger": "3.496.0",
-        "@aws-sdk/middleware-recursion-detection": "3.496.0",
-        "@aws-sdk/middleware-sdk-s3": "3.496.0",
-        "@aws-sdk/middleware-signing": "3.496.0",
-        "@aws-sdk/middleware-ssec": "3.496.0",
-        "@aws-sdk/middleware-user-agent": "3.496.0",
-        "@aws-sdk/region-config-resolver": "3.496.0",
-        "@aws-sdk/signature-v4-multi-region": "3.496.0",
-        "@aws-sdk/types": "3.496.0",
-        "@aws-sdk/util-endpoints": "3.496.0",
-        "@aws-sdk/util-user-agent-browser": "3.496.0",
-        "@aws-sdk/util-user-agent-node": "3.496.0",
-        "@aws-sdk/xml-builder": "3.496.0",
-        "@smithy/config-resolver": "^2.1.1",
-        "@smithy/core": "^1.3.1",
-        "@smithy/eventstream-serde-browser": "^2.1.1",
-        "@smithy/eventstream-serde-config-resolver": "^2.1.1",
-        "@smithy/eventstream-serde-node": "^2.1.1",
-        "@smithy/fetch-http-handler": "^2.4.1",
-        "@smithy/hash-blob-browser": "^2.1.1",
-        "@smithy/hash-node": "^2.1.1",
-        "@smithy/hash-stream-node": "^2.1.1",
-        "@smithy/invalid-dependency": "^2.1.1",
-        "@smithy/md5-js": "^2.1.1",
-        "@smithy/middleware-content-length": "^2.1.1",
-        "@smithy/middleware-endpoint": "^2.4.1",
-        "@smithy/middleware-retry": "^2.1.1",
-        "@smithy/middleware-serde": "^2.1.1",
-        "@smithy/middleware-stack": "^2.1.1",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/node-http-handler": "^2.3.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/url-parser": "^2.1.1",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.1",
-        "@smithy/util-defaults-mode-node": "^2.1.1",
-        "@smithy/util-endpoints": "^1.1.1",
-        "@smithy/util-retry": "^2.1.1",
-        "@smithy/util-stream": "^2.1.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "@smithy/util-waiter": "^2.1.1",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.633.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.633.0.tgz",
+      "integrity": "sha512-KPwNGlZlCRUADNTvwPJmvDvlh8N/jxjcv5e71M/mWxLXwSPdlHlRjVSBL1/CPSXUr86XRAsPL+BCRkdiytUhbg==",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.632.0",
+        "@aws-sdk/client-sts": "3.632.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.632.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.620.0",
+        "@aws-sdk/middleware-expect-continue": "3.620.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.620.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-location-constraint": "3.609.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-sdk-s3": "3.633.0",
+        "@aws-sdk/middleware-ssec": "3.609.0",
+        "@aws-sdk/middleware-user-agent": "3.632.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/signature-v4-multi-region": "3.633.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.632.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@aws-sdk/xml-builder": "3.609.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/eventstream-serde-browser": "^3.0.6",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
+        "@smithy/eventstream-serde-node": "^3.0.5",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-blob-browser": "^3.1.2",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/hash-stream-node": "^3.1.2",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/md5-js": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-stream": "^3.1.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
-      "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.632.0.tgz",
+      "integrity": "sha512-iYWHiKBz44m3chCFvtvHnvCpL2rALzyr1e6tOZV3dLlOKtQtDUlPy6OtnXDu4y+wyJCniy8ivG3+LAe4klzn1Q==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.496.0",
-        "@aws-sdk/middleware-host-header": "3.496.0",
-        "@aws-sdk/middleware-logger": "3.496.0",
-        "@aws-sdk/middleware-recursion-detection": "3.496.0",
-        "@aws-sdk/middleware-user-agent": "3.496.0",
-        "@aws-sdk/region-config-resolver": "3.496.0",
-        "@aws-sdk/types": "3.496.0",
-        "@aws-sdk/util-endpoints": "3.496.0",
-        "@aws-sdk/util-user-agent-browser": "3.496.0",
-        "@aws-sdk/util-user-agent-node": "3.496.0",
-        "@smithy/config-resolver": "^2.1.1",
-        "@smithy/core": "^1.3.1",
-        "@smithy/fetch-http-handler": "^2.4.1",
-        "@smithy/hash-node": "^2.1.1",
-        "@smithy/invalid-dependency": "^2.1.1",
-        "@smithy/middleware-content-length": "^2.1.1",
-        "@smithy/middleware-endpoint": "^2.4.1",
-        "@smithy/middleware-retry": "^2.1.1",
-        "@smithy/middleware-serde": "^2.1.1",
-        "@smithy/middleware-stack": "^2.1.1",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/node-http-handler": "^2.3.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/url-parser": "^2.1.1",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.1",
-        "@smithy/util-defaults-mode-node": "^2.1.1",
-        "@smithy/util-endpoints": "^1.1.1",
-        "@smithy/util-retry": "^2.1.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.632.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.632.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.632.0.tgz",
+      "integrity": "sha512-Oh1fIWaoZluihOCb/zDEpRTi+6an82fgJz7fyRBugyLhEtDjmvpCQ3oKjzaOhoN+4EvXAm1ZS/ZgpvXBlIRTgw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.632.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.632.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.632.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.632.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.496.0.tgz",
-      "integrity": "sha512-3pSdqgegdwbK3CT1WvGHhA+Bf91R9cr8G1Ynp+iU2wZvy8ueJfMUk0NYfjo3EEv0YhSbMLKuduzZfvQHFHXYhw==",
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.632.0.tgz",
+      "integrity": "sha512-Ss5cBH09icpTvT+jtGGuQlRdwtO7RyE9BF4ZV/CEPATdd9whtJt4Qxdya8BUnkWR7h5HHTrQHqai3YVYjku41A==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.496.0",
-        "@aws-sdk/credential-provider-node": "3.496.0",
-        "@aws-sdk/middleware-host-header": "3.496.0",
-        "@aws-sdk/middleware-logger": "3.496.0",
-        "@aws-sdk/middleware-recursion-detection": "3.496.0",
-        "@aws-sdk/middleware-user-agent": "3.496.0",
-        "@aws-sdk/region-config-resolver": "3.496.0",
-        "@aws-sdk/types": "3.496.0",
-        "@aws-sdk/util-endpoints": "3.496.0",
-        "@aws-sdk/util-user-agent-browser": "3.496.0",
-        "@aws-sdk/util-user-agent-node": "3.496.0",
-        "@smithy/config-resolver": "^2.1.1",
-        "@smithy/core": "^1.3.1",
-        "@smithy/fetch-http-handler": "^2.4.1",
-        "@smithy/hash-node": "^2.1.1",
-        "@smithy/invalid-dependency": "^2.1.1",
-        "@smithy/middleware-content-length": "^2.1.1",
-        "@smithy/middleware-endpoint": "^2.4.1",
-        "@smithy/middleware-retry": "^2.1.1",
-        "@smithy/middleware-serde": "^2.1.1",
-        "@smithy/middleware-stack": "^2.1.1",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/node-http-handler": "^2.3.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/url-parser": "^2.1.1",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.1",
-        "@smithy/util-defaults-mode-node": "^2.1.1",
-        "@smithy/util-endpoints": "^1.1.1",
-        "@smithy/util-middleware": "^2.1.1",
-        "@smithy/util-retry": "^2.1.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.632.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.632.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.632.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.632.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
-      "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
+      "version": "3.629.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+      "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
       "dependencies": {
-        "@smithy/core": "^1.3.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/signature-v4": "^2.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/core": "^2.3.2",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
-      "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.622.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
+      "integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
-      "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.632.0.tgz",
+      "integrity": "sha512-m6epoW41xa1ajU5OiHcmQHoGVtrbXBaRBOUhlCLZmcaqMLYsboM4iD/WZP8aatKEON5tTnVXh/4StV8D/+wemw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.496.0",
-        "@aws-sdk/credential-provider-process": "3.496.0",
-        "@aws-sdk/credential-provider-sso": "3.496.0",
-        "@aws-sdk/credential-provider-web-identity": "3.496.0",
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/credential-provider-imds": "^2.2.1",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.632.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.632.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
-      "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.632.0.tgz",
+      "integrity": "sha512-cL8fuJWm/xQBO4XJPkeuZzl3XinIn9EExWgzpG48NRMKR5us1RI/ucv7xFbBBaG+r/sDR2HpYBIA3lVIpm1H3Q==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.496.0",
-        "@aws-sdk/credential-provider-ini": "3.496.0",
-        "@aws-sdk/credential-provider-process": "3.496.0",
-        "@aws-sdk/credential-provider-sso": "3.496.0",
-        "@aws-sdk/credential-provider-web-identity": "3.496.0",
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/credential-provider-imds": "^2.2.1",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-ini": "3.632.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.632.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
-      "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
-      "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.632.0.tgz",
+      "integrity": "sha512-P/4wB6j7ym5QCPTL2xlMfvf2NcXSh+z0jmsZP4WW/tVwab4hvgabPPbLeEZDSWZ0BpgtxKGvRq0GSHuGeirQbA==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.496.0",
-        "@aws-sdk/token-providers": "3.496.0",
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.632.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
-      "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
@@ -1147,155 +1292,143 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.496.0.tgz",
-      "integrity": "sha512-B+ilBMSs3+LJuo2bl2KB8GFdu+8PPVtYEWtwhNkmnaU8iMisgMBp5uuM8sUDvJX7I4iSF0WbgnhguX4cJqfAew==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.620.0.tgz",
+      "integrity": "sha512-eGLL0W6L3HDb3OACyetZYOWpHJ+gLo0TehQKeQyy2G8vTYXqNTeqYhuI6up9HVjBzU9eQiULVQETmgQs7TFaRg==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@aws-sdk/util-arn-parser": "3.495.0",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-config-provider": "^2.2.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.496.0.tgz",
-      "integrity": "sha512-+exo5DVc+BeDus2iI6Fz1thefHGDXxUhHZ+4VHQ6HkStMy3Y22HugyEGHSQZmtRL86Hjr7dFbEWFsC47a2ItGA==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.620.0.tgz",
+      "integrity": "sha512-QXeRFMLfyQ31nAHLbiTLtk0oHzG9QLMaof5jIfqcUwnOkO8YnQdeqzakrg1Alpy/VQ7aqzIi8qypkBe2KXZz0A==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.496.0.tgz",
-      "integrity": "sha512-yQIWfjEMvgsAJ7ku224vXDjXPD+f9zfKZFialJva8VUlEr7hQp4CQ0rxV3YThSaixKEDDs5k6kOjWAd2BPGr2A==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.620.0.tgz",
+      "integrity": "sha512-ftz+NW7qka2sVuwnnO1IzBku5ccP+s5qZGeRTPgrKB7OzRW85gthvIo1vQR2w+OwHFk7WJbbhhWwbCbktnP4UA==",
       "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/is-array-buffer": "^2.1.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
-      "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.496.0.tgz",
-      "integrity": "sha512-i4ocJ2Zs86OtPREbB18InFukhqg2qtBxb5gywv79IHDPVmpOYE4m/3v3yGUrkjfF2GTlUL0k5FskNNqw41yfng==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.609.0.tgz",
+      "integrity": "sha512-xzsdoTkszGVqGVPjUmgoP7TORiByLueMHieI1fhQL888WPdqctwAx3ES6d/bA9Q/i8jnc6hs+Fjhy8UvBTkE9A==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
-      "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
-      "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.496.0.tgz",
-      "integrity": "sha512-OKrTPzubisQCQzPuF4G7jmbYt71o6W7oefmW9zm1MpGokRSJeC9zv4aT1gkMglpXEHgvL0S5fUVGi0AtF/F8Kw==",
+      "version": "3.633.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.633.0.tgz",
+      "integrity": "sha512-7jjmWVw28wIHOdrHyTCvwKr1EYGrZI13DviwAOwRC0y9dB8gGCdRiA4fNczripUBxolCCE9mpqLrqy5pXtTzvA==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@aws-sdk/util-arn-parser": "3.495.0",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/signature-v4": "^2.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-config-provider": "^2.2.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/core": "^2.3.2",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-stream": "^3.1.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
-      "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/signature-v4": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-middleware": "^2.1.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.496.0.tgz",
-      "integrity": "sha512-6RUFEgGqKGq8N8W9tsctS8KRlYnmD/yiExb/LvblCJqV1DWoD0psRFWNz8TQZtujHklG5dHjuq+aN/qicjBNdw==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.609.0.tgz",
+      "integrity": "sha512-GZSD1s7+JswWOTamVap79QiDaIV7byJFssBW68GYjyRS5EBjNfwA/8s+6uE6g39R3ojyTbYOmvcANoZEhSULXg==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
@@ -1310,18 +1443,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
-      "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.632.0.tgz",
+      "integrity": "sha512-yY/sFsHKwG9yzSf/DTclqWJaGPI2gPBJDCGBujSqTG1zlS7Ot4fqi91DZ6088BFWzbOorDzJFcAhAEFzc6LuQg==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@aws-sdk/util-endpoints": "3.496.0",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.632.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
@@ -1366,19 +1499,19 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
-      "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-config-provider": "^2.2.1",
-        "@smithy/util-middleware": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
@@ -1472,19 +1605,19 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.496.0.tgz",
-      "integrity": "sha512-zi3cL8+dRVSvC0PA6votwEHF4l9uxOyQTiRfgpFgzJ9iiPbsrtWCalGCwN0UyzmeDv7eViU6FK1YTHH/OgDJ4A==",
+      "version": "3.633.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.633.0.tgz",
+      "integrity": "sha512-96F7Mx4lybMZdE0TTEkw6EKpeB0hxqp3J8fUJasesekTnO7jsklc47GHL5R3whyS/L4/JaPazm0Pi2DEH3kw1w==",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.496.0",
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/signature-v4": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/middleware-sdk-s3": "3.633.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/types": {
@@ -1517,73 +1650,44 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
-      "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.496.0",
-        "@aws-sdk/middleware-logger": "3.496.0",
-        "@aws-sdk/middleware-recursion-detection": "3.496.0",
-        "@aws-sdk/middleware-user-agent": "3.496.0",
-        "@aws-sdk/region-config-resolver": "3.496.0",
-        "@aws-sdk/types": "3.496.0",
-        "@aws-sdk/util-endpoints": "3.496.0",
-        "@aws-sdk/util-user-agent-browser": "3.496.0",
-        "@aws-sdk/util-user-agent-node": "3.496.0",
-        "@smithy/config-resolver": "^2.1.1",
-        "@smithy/fetch-http-handler": "^2.4.1",
-        "@smithy/hash-node": "^2.1.1",
-        "@smithy/invalid-dependency": "^2.1.1",
-        "@smithy/middleware-content-length": "^2.1.1",
-        "@smithy/middleware-endpoint": "^2.4.1",
-        "@smithy/middleware-retry": "^2.1.1",
-        "@smithy/middleware-serde": "^2.1.1",
-        "@smithy/middleware-stack": "^2.1.1",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/node-http-handler": "^2.3.1",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/url-parser": "^2.1.1",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-body-length-browser": "^2.1.1",
-        "@smithy/util-body-length-node": "^2.2.1",
-        "@smithy/util-defaults-mode-browser": "^2.1.1",
-        "@smithy/util-defaults-mode-node": "^2.1.1",
-        "@smithy/util-endpoints": "^1.1.1",
-        "@smithy/util-retry": "^2.1.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
-      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.495.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.495.0.tgz",
-      "integrity": "sha512-hwdA3XAippSEUxs7jpznwD63YYFR+LtQvlEcebPTgWR9oQgG9TfS+39PUfbnEeje1ICuOrN3lrFqFbmP9uzbMg==",
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.568.0.tgz",
+      "integrity": "sha512-XUKJWWo+KOB7fbnPP0+g/o5Ulku/X53t7i/h+sPHr5xxYTJJ9CYnbToo95mzxe7xWvkLrsNtJ8L+MnNn9INs2w==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-create-request": {
@@ -1609,17 +1713,17 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
-      "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+      "version": "3.632.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.632.0.tgz",
+      "integrity": "sha512-LlYMU8pAbcEQphOpE6xaNLJ8kPGhklZZTVzZVpVW477NaaGgoGTMYNXTABYHcxeF5E2lLrxql9OmVpvr8GWN8Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-endpoints": "^1.1.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
@@ -1655,14 +1759,14 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.495.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.495.0.tgz",
-      "integrity": "sha512-MfaPXT0kLX2tQaR90saBT9fWQq2DHqSSJRzW+MZWsmF+y5LGCOhO22ac/2o6TKSQm7h0HRc2GaADqYYYor62yg==",
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+      "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
@@ -1688,28 +1792,28 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
-      "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/types": "^2.9.1",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
-      "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "dependencies": {
-        "@aws-sdk/types": "3.496.0",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -1720,24 +1824,16 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.496.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.496.0.tgz",
-      "integrity": "sha512-GvEjh537IIeOw1ZkZuB37sV12u+ipS5Z1dwjEC/HAvhl5ac23ULtTr1/n+U1gLNN+BAKSWjKiQ2ksj8DiUzeyw==",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.609.0.tgz",
+      "integrity": "sha512-l9XxNcA4HX98rwCC2/KoiWcmEiRfZe4G+mYwDbCFT87JIMj6GBhLDkAzr/W8KAaA2IDr8Vc6J8fZPgVulxxfMA==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3851,648 +3947,643 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
-      "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/chunked-blob-reader": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.1.1.tgz",
-      "integrity": "sha512-NjNFCKxC4jVvn+lUr3Yo4/PmUJj3tbyqH6GNHueyTGS5Q27vlEJ1MkNhUDV8QGxJI7Bodnc2pD18lU2zRfhHlQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-3.0.0.tgz",
+      "integrity": "sha512-sbnURCwjF0gSToGlsBiAmd1lRCmSn72nu9axfJu5lIx6RUEgHu6GwTMbqCdhQSi0Pumcm5vFxsi9XWXb2mTaoA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.1.1.tgz",
-      "integrity": "sha512-zNW+43dltfNMUrBEYLMWgI8lQr0uhtTcUyxkgC9EP4j17WREzgSFMPUFVrVV6Rc2+QtWERYjb4tzZnQGa7R9fQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.0.tgz",
+      "integrity": "sha512-VDkpCYW+peSuM4zJip5WDfqvg2Mo/e8yxOv3VF1m11y7B8KKMKVFtmZWDe36Fvk8rGuWrPZHHXZ7rR7uM5yWyg==",
       "dependencies": {
-        "@smithy/util-base64": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
-      "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-config-provider": "^2.2.1",
-        "@smithy/util-middleware": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-tf+NIu9FkOh312b6M9G4D68is4Xr7qptzaZGZUREELF8ysE1yLKphqt7nsomjKZVwW7WE5pDDex9idowNGRQ/Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-cHXq+FneIF/KJbt4q4pjN186+Jf4ZB0ZOqEaZMBhT79srEyGDDBV31NqBRBjazz8ppQ1bJbDJMY9ba5wKFV36w==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.4.1",
-        "@smithy/middleware-retry": "^2.1.1",
-        "@smithy/middleware-serde": "^2.1.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-middleware": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
-      "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/url-parser": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
-      "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.2.tgz",
+      "integrity": "sha512-0mBcu49JWt4MXhrhRAlxASNy0IjDRFU+aWNDRal9OtUJvJNiwDuyKMUONSOjLjSCeGwZaE0wOErdqULer8r7yw==",
       "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-hex-encoding": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.1.1.tgz",
-      "integrity": "sha512-JvEdCmGlZUay5VtlT8/kdR6FlvqTDUiJecMjXsBb0+k1H/qc9ME5n2XKPo8q/MZwEIA1GmGgYMokKGjVvMiDow==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.6.tgz",
+      "integrity": "sha512-2hM54UWQUOrki4BtsUI1WzmD13/SeaqT/AB3EUJKbcver/WgKNaiJ5y5F5XXuVe6UekffVzuUDrBZVAA3AWRpQ==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-serde-universal": "^3.0.5",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.1.1.tgz",
-      "integrity": "sha512-EqNqXYp3+dk//NmW3NAgQr9bEQ7fsu/CcxQmTiq07JlaIcne/CBWpMZETyXm9w5LXkhduBsdXdlMscfDUDn2fA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.3.tgz",
+      "integrity": "sha512-NVTYjOuYpGfrN/VbRQgn31x73KDLfCXCsFdad8DiIc3IcdxL+dYA9zEQPyOP7Fy2QL8CPy2WE4WCUD+ZsLNfaQ==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.1.1.tgz",
-      "integrity": "sha512-LF882q/aFidFNDX7uROAGxq3H0B7rjyPkV6QDn6/KDQ+CG7AFkRccjxRf1xqajq/Pe4bMGGr+VKAaoF6lELIQw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.5.tgz",
+      "integrity": "sha512-+upXvnHNyZP095s11jF5dhGw/Ihzqwl5G+/KtMnoQOpdfC3B5HYCcDVG9EmgkhJMXJlM64PyN5gjJl0uXFQehQ==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-serde-universal": "^3.0.5",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.1.1.tgz",
-      "integrity": "sha512-LR0mMT+XIYTxk4k2fIxEA1BPtW3685QlqufUEUAX1AJcfFfxNDKEvuCRZbO8ntJb10DrIFVJR9vb0MhDCi0sAQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.5.tgz",
+      "integrity": "sha512-5u/nXbyoh1s4QxrvNre9V6vfyoLWuiVvvd5TlZjGThIikc3G+uNiG9uOTCWweSRjv1asdDIWK7nOmN7le4RYHQ==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-codec": "^3.1.2",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
-      "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/querystring-builder": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-base64": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.1.1.tgz",
-      "integrity": "sha512-jizu1+2PAUjiGIfRtlPEU8Yo6zn+d78ti/ZHDesdf1SUn2BuZW433JlPoCOLH3dBoEEvTgLvQ8tUGSoTTALA+A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.2.tgz",
+      "integrity": "sha512-hAbfqN2UbISltakCC2TP0kx4LqXBttEv2MqSPE98gVuDFMf05lU+TpC41QtqGP3Ff5A3GwZMPfKnEy0VmEUpmg==",
       "dependencies": {
-        "@smithy/chunked-blob-reader": "^2.1.1",
-        "@smithy/chunked-blob-reader-native": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/chunked-blob-reader": "^3.0.0",
+        "@smithy/chunked-blob-reader-native": "^3.0.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
-      "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-buffer-from": "^2.1.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.1.1.tgz",
-      "integrity": "sha512-VgDaKcfCy0iHcmtAZgZ3Yw9g37Gkn2JsQiMtFQXUh8Wmo3GfNgDwLOtdhJ272pOT7DStzpe9cNr+eV5Au8KfQA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.2.tgz",
+      "integrity": "sha512-PBgDMeEdDzi6JxKwbfBtwQG9eT9cVwsf0dZzLXoJF4sHKHs5HEo/3lJWpn6jibfJwT34I1EBXpBnZE8AxAft6g==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
-      "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
-      "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.1.1.tgz",
-      "integrity": "sha512-L3MbIYBIdLlT+MWTYrdVSv/dow1+6iZ1Ad7xS0OHxTTs17d753ZcpOV4Ro7M7tRAVWML/sg2IAp/zzCb6aAttg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.3.tgz",
+      "integrity": "sha512-O/SAkGVwpWmelpj/8yDtsaVe6sINHLB1q8YE/+ZQbDxIw3SRLbTZuRaI10K12sVoENdnHqzPp5i3/H+BcZ3m3Q==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
-      "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
-      "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.1.1",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/url-parser": "^2.1.1",
-        "@smithy/util-middleware": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
-      "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
+      "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/service-error-classification": "^2.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-middleware": "^2.1.1",
-        "@smithy/util-retry": "^2.1.1",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
-      "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
-      "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
-      "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
       "dependencies": {
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
-      "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.1.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/querystring-builder": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
-      "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
-      "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
-      "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-uri-escape": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
-      "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
-      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
       "dependencies": {
-        "@smithy/types": "^2.9.1"
+        "@smithy/types": "^3.3.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
-      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
-      "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.1.1",
-        "@smithy/is-array-buffer": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-hex-encoding": "^2.1.1",
-        "@smithy/util-middleware": "^2.1.1",
-        "@smithy/util-uri-escape": "^2.1.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
-      "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
+      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.4.1",
-        "@smithy/middleware-stack": "^2.1.1",
-        "@smithy/protocol-http": "^3.1.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-stream": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
-      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
-      "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
-      "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
-      "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
-      "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
-      "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
-      "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
-      "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
+      "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.1.1.tgz",
-      "integrity": "sha512-tYVrc+w+jSBfBd267KDnvSGOh4NMz+wVH7v4CClDbkdPfnjvImBZsOURncT5jsFwR9KCuDyPoSZq4Pa6+eCUrA==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
+      "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.1.1",
-        "@smithy/credential-provider-imds": "^2.2.1",
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/property-provider": "^2.1.1",
-        "@smithy/smithy-client": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
-      "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+      "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.2.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
-      "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
-      "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
-      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">= 14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
-      "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.4.1",
-        "@smithy/node-http-handler": "^2.3.1",
-        "@smithy/types": "^2.9.1",
-        "@smithy/util-base64": "^2.1.1",
-        "@smithy/util-buffer-from": "^2.1.1",
-        "@smithy/util-hex-encoding": "^2.1.1",
-        "@smithy/util-utf8": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
-      "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
-      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.1.1",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
-      "integrity": "sha512-kYy6BLJJNif+uqNENtJqWdXcpqo1LS+nj1AfXcDhOpqpSHJSAkVySLyZV9fkmuVO21lzGoxjvd1imGGJHph/IA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+      "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -7216,17 +7307,17 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@apollo/subgraph": "^2.0.5",
-    "@aws-sdk/client-s3": "^3.137.0",
+    "@aws-sdk/client-s3": "^3.525.0",
     "@aws-sdk/s3-request-presigner": "3.67.0",
     "@nestjs/apollo": "^12.0.0",
     "@nestjs/common": "^10.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,16 +7,18 @@ import { DatabaseModule } from './database/database.module';
 import { FormsModule } from './forms';
 import { GraphQLModule } from './graphql/graphql.module';
 import { UsersModule } from './users/users.module';
+import { DocumentsModule } from './documents';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     DatabaseModule.forRoot(),
     GraphQLModule,
+    DocumentsModule,
     UsersModule,
     FormsModule,
   ],
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule { }

--- a/src/documents/documents.controller.ts
+++ b/src/documents/documents.controller.ts
@@ -1,0 +1,77 @@
+
+
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { DocumentsService } from './documents.service';
+import { Role } from 'src/util/constants';
+import { Roles } from '@/auth/roles.decorator';
+import { ResidueType } from './dtos';
+
+@ApiTags('documents')
+@ApiBearerAuth('access-token')
+@Controller({ path: 'documents', version: '1' })
+export class DocumentsController {
+  constructor(private readonly documentsService: DocumentsService) { }
+
+  @Get('video-url')
+  @ApiOperation({
+    summary: 'Get document video URL by residue type',
+    description: 'Returns the video URL for the specified residue type and form ID',
+  })
+  @ApiQuery({
+    type: 'string',
+    name: 'formId',
+    example: '0000742d-ee03-463b-a558-d79728f8a171',
+  })
+  @ApiQuery({
+    name: 'residueType',
+    enum: ResidueType,
+    example: ResidueType.GLASS
+  })
+  @ApiOkResponse({
+    description: 'Returns the video URL for the specified residue type and form ID',
+    type: String,
+  })
+  @Roles(Role.Admin)
+  getDocumentVideoUrlByResidue(
+    @Query('formId') formId: string,
+    @Query('residueType') residueType: ResidueType,
+  ) {
+    return this.documentsService.getDocumentVideoUrlByResidue(formId, residueType);
+  }
+
+  @Get('invoices-url')
+  @ApiOperation({
+    summary: 'Get document invoices URL by residue type',
+    description: 'Returns the invoices URL for the specified residue type and form ID',
+  })
+  @ApiQuery({
+    type: 'string',
+    name: 'formId',
+    example: '0000742d-ee03-463b-a558-d79728f8a171',
+  })
+  @ApiQuery({
+    name: 'residueType',
+    enum: ResidueType,
+    example: ResidueType.GLASS
+  })
+  @ApiOkResponse({
+    description: 'Returns the invoices URL for the specified residue type and form ID',
+    type: [String],
+  })
+  @Roles(Role.Admin)
+  getDocumentInvoicesUrlByResidue(
+    @Query('formId') formId: string,
+    @Query('residueType') residueType: ResidueType,
+  ) {
+    return this.documentsService.getDocumentInvoicesUrlByResidue(formId, residueType);
+  }
+}

--- a/src/documents/documents.module.ts
+++ b/src/documents/documents.module.ts
@@ -3,10 +3,12 @@ import { Module } from '@nestjs/common';
 import { S3Module } from '@/s3';
 
 import { DocumentsService } from './documents.service';
+import { DocumentsController } from './documents.controller';
 
 @Module({
   imports: [S3Module],
+  controllers: [DocumentsController],
   providers: [DocumentsService],
   exports: [DocumentsService],
 })
-export class DocumentsModule {}
+export class DocumentsModule { }

--- a/src/documents/index.ts
+++ b/src/documents/index.ts
@@ -1,3 +1,5 @@
 export * from './documents.module';
 export * from './documents.service';
+export * from './documents.controller';
+
 export * from './dtos';


### PR DESCRIPTION
I’ve added the two documents endpoints for REST, and these two methods are only allowed for the admin. However, when the REST endpoints are currently being called in the application, we’re always allowing execution regardless of the user’s role. Here’s a screenshot of the code that enables this. We can implement the proper checks in a new task.

<img width="502" alt="Screenshot 2024-08-19 at 00 16 28" src="https://github.com/user-attachments/assets/e73789bc-a99a-4261-a339-5561c51f8e4a">
